### PR TITLE
Add config ID to links (ALP-150)

### DIFF
--- a/SDKTest/SdkTest.cs
+++ b/SDKTest/SdkTest.cs
@@ -372,6 +372,32 @@ namespace SDKTest
 
         }
 
+        [TestMethod]
+        public async Task UploadFilesInLinkDataTest()
+        {
+
+            Sdk<Object> sdk = GetSdk();
+
+            IDictionary<string, object> data = new Dictionary<string, object>
+            {
+                ["weight"] = "123",
+                ["valid"] = true,
+                ["operators"] = new string[] { "1", "2" },
+                ["operation"] = "my new operation 1"
+            };
+
+            data.Add("Certificate1", FileWrapper.FromFilePath(Path.GetFullPath("../../Resources/TestFile1.txt")));
+            data.Add("Certificates", new Identifiable[] { FileWrapper.FromFilePath(Path.GetFullPath("../../Resources/TestFile1.txt")) });
+
+            await sdk.UploadFilesInLinkData(data);
+
+            Assert.IsTrue(FileRecord.IsFileRecord(data["Certificate1"]));
+            Assert.IsTrue(FileRecord.IsFileRecord(((object[]) data["Certificates"])[0]));
+
+            Console.WriteLine(JsonHelper.ToJson(data));
+
+        }
+
 
         [TestMethod]
         public async Task downloadFilesInObjectTest()

--- a/Sdk/Properties/AssemblyInfo.cs
+++ b/Sdk/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.0.21.0")]
-[assembly: AssemblyFileVersion("0.0.21.0")]
+[assembly: AssemblyVersion("0.0.23.0")]
+[assembly: AssemblyFileVersion("0.0.23.0")]

--- a/Sdk/Properties/AssemblyInfo.cs
+++ b/Sdk/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.0.23.0")]
-[assembly: AssemblyFileVersion("0.0.23.0")]
+[assembly: AssemblyVersion("0.1.0.0")]
+[assembly: AssemblyFileVersion("0.1.0.0")]

--- a/Sdk/SDK.nuspec
+++ b/Sdk/SDK.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>Stratumn.SDK</id> 
-    <version>0.0.23.0</version>
+    <version>0.1.0.0</version>
     <title>Stratumn SDK</title>
     <authors>Stratumn</authors>
     <owners>Stratumn</owners>

--- a/Sdk/SDK.nuspec
+++ b/Sdk/SDK.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>Stratumn.SDK</id> 
-    <version>0.0.21.0</version>
+    <version>0.0.23.0</version>
     <title>Stratumn SDK</title>
     <authors>Stratumn</authors>
     <owners>Stratumn</owners>

--- a/Sdk/Sdk/Model/Sdk/SdkConfig.cs
+++ b/Sdk/Sdk/Model/Sdk/SdkConfig.cs
@@ -17,6 +17,10 @@ namespace Stratumn.Sdk.Model.Sdk
         /// </summary>
         private string workflowId;
         /// <summary>
+        /// The workflow config id
+        /// </summary>
+        private string configId;
+        /// <summary>
         /// The user id
         /// </summary>
         private string userId;
@@ -42,9 +46,10 @@ namespace Stratumn.Sdk.Model.Sdk
         {
         }
 
-        public SdkConfig(string workflowId, string userId, string accountId, string groupId, string ownerId, Ed25519PrivateKeyParameters signingPrivateKey)
+        public SdkConfig(string workflowId, string configId, string userId, string accountId, string groupId, string ownerId, Ed25519PrivateKeyParameters signingPrivateKey)
         {
             this.workflowId = workflowId;
+            this.configId = configId;
             this.userId = userId;
             this.accountId = accountId;
             this.groupId = groupId;
@@ -62,6 +67,18 @@ namespace Stratumn.Sdk.Model.Sdk
             set
             {
                 this.workflowId = value;
+            }
+        }
+
+        public virtual string ConfigId
+        {
+            get
+            {
+                return configId;
+            }
+            set
+            {
+                this.configId = value;
             }
         }
 

--- a/Sdk/Sdk/Model/Trace/TraceLinkBuilderConfig.cs
+++ b/Sdk/Sdk/Model/Trace/TraceLinkBuilderConfig.cs
@@ -13,6 +13,7 @@ namespace Stratumn.Sdk.Model.Trace
     {
 
         private string workflowId;
+        private string configId;
         private ITraceLink<TLinkData> parentLink;
 
         public TraceLinkBuilderConfig()
@@ -34,6 +35,17 @@ namespace Stratumn.Sdk.Model.Trace
             set
             {
                 this.workflowId = value;
+            }
+        }
+        public string ConfigId
+        {
+            get
+            {
+                return configId;
+            }
+            set
+            {
+                this.configId = value;
             }
         }
         public ITraceLink<TLinkData> ParentLink

--- a/Sdk/Sdk/Model/Trace/TraceLinkMetaData.cs
+++ b/Sdk/Sdk/Model/Trace/TraceLinkMetaData.cs
@@ -17,6 +17,9 @@ namespace Stratumn.Sdk.Model.Trace
         [JsonProperty(PropertyName = "ownerId")]
         public string OwnerId { get; set; }
 
+        [JsonProperty(PropertyName = "configId")]
+        public string ConfigId { get; set; }
+
         [JsonProperty(PropertyName = "groupId")]
         public string GroupId { get; set; }
 
@@ -42,11 +45,15 @@ namespace Stratumn.Sdk.Model.Trace
         {
         }
 
-        internal TraceLinkMetaData(string ownerId, string groupId, string formId, string lastFormId, DateTime createdAt, string createdById, string[] inputs)
+        internal TraceLinkMetaData(string ownerId, string configId, string groupId, string formId, string lastFormId, DateTime createdAt, string createdById, string[] inputs)
         {
             if (string.ReferenceEquals(ownerId, null))
             {
                 throw new System.ArgumentException("ownerId cannot be null");
+            }
+            if (string.ReferenceEquals(configId, null))
+            {
+                throw new System.ArgumentException("configId cannot be null");
             }
             if (string.ReferenceEquals(groupId, null))
             {
@@ -74,6 +81,7 @@ namespace Stratumn.Sdk.Model.Trace
             }
 
             this.OwnerId = ownerId;
+            this.ConfigId = configId;
             this.GroupId = groupId;
             this.FormId = formId;
             this.LastFormId = lastFormId;

--- a/Sdk/Sdk/TraceLinkBuilder.cs
+++ b/Sdk/Sdk/TraceLinkBuilder.cs
@@ -55,6 +55,7 @@
             // set the created at timestamp 
             this.metadata = new TraceLinkMetaData();
             this.metadata.CreatedAt = DateTime.Now;
+            this.metadata.ConfigId = cfg.ConfigId;
 
             // if parent link was provided set the parent hash and priority
             if (this.parentLink != null)
@@ -255,10 +256,21 @@
         }
 
         /// <summary>
+        /// To set the metadata configId.
+        /// </summary>
+        /// <param name="userId">The userId<see cref="string"/></param>
+        /// <returns>The <see cref="TraceLinkBuilder{TLinkData}"/></returns>
+        public virtual TraceLinkBuilder<TLinkData> WithConfigId(string configId)
+        {
+            this.metadata.ConfigId = configId;
+            return this;
+        }
+
+        /// <summary>
         /// The Build
         /// </summary>
         /// <returns>The <see cref="TraceLink{TLinkData}"/></returns>
-        public virtual TraceLink<TLinkData> Build()
+        public new virtual TraceLink<TLinkData> Build()
         {
             base.WithMetadata(this.metadata);
             Link link = base.Build();

--- a/Sdk/Sdk/graphql.cs
+++ b/Sdk/Sdk/graphql.cs
@@ -91,6 +91,7 @@ namespace Stratumn.Sdk
                                                 }
                                               }
                                               workflow: workflowByRowId(rowId: $workflowId) {
+                                                config { id: rowId }
                                                 groups {
                                                   nodes {
                                                     groupId: rowId


### PR DESCRIPTION
1. get the active wf config ID in the sdk config
2. add it to the link metadata
3. if the API returns an error because of the config ID being deprecated, update the config ID and retry.
4. In case something unexpected happens and the backend say that wf config is deprecated again, do not retry. This will allow us to avoid infinite loops in case of bad backend implementation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/sdk-csharp/10)
<!-- Reviewable:end -->
