### PR TITLE
Fix blob file encryption

### DIFF
--- a/Sdk/Properties/AssemblyInfo.cs
+++ b/Sdk/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.1.0.0")]
-[assembly: AssemblyFileVersion("0.1.0.0")]
+[assembly: AssemblyVersion("0.1.1.0")]
+[assembly: AssemblyFileVersion("0.1.1.0")]

--- a/Sdk/SDK.nuspec
+++ b/Sdk/SDK.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>Stratumn.SDK</id> 
-    <version>0.1.0.0</version>
+    <version>0.1.1.0</version>
     <title>Stratumn SDK</title>
     <authors>Stratumn</authors>
     <owners>Stratumn</owners>

--- a/Sdk/Sdk/FileBlobWrapper.cs
+++ b/Sdk/Sdk/FileBlobWrapper.cs
@@ -16,7 +16,14 @@ namespace Stratumn.Sdk
         public MemoryStream Blob { get; set; }
         public Model.File.FileInfo FileInfo { get; set; }
 
-        public FileBlobWrapper(MemoryStream blob, Model.File.FileInfo fileInfo) : base(fileInfo.Key == null || fileInfo.Key == "", fileInfo.Key)
+        public FileBlobWrapper(MemoryStream blob, Model.File.FileInfo fileInfo) : base(false, fileInfo.Key)
+        {
+            this.Blob = blob;
+            this.FileInfo = fileInfo;
+
+        }
+
+        internal FileBlobWrapper(MemoryStream blob, Model.File.FileInfo fileInfo, bool disableEncryption) : base(disableEncryption, fileInfo.Key)
         {
             this.Blob = blob;
             this.FileInfo = fileInfo;

--- a/Sdk/Sdk/FileRecord.cs
+++ b/Sdk/Sdk/FileRecord.cs
@@ -117,6 +117,7 @@ namespace Stratumn.Sdk
 
                         Object ob = JsonHelper.FromJson<FileRecord>(json);
                         String json2 = JsonHelper.ToCanonicalJson(ob);
+
                         if (json2.Equals(json))
                             isFileRecord = true;
                     }
@@ -132,12 +133,17 @@ namespace Stratumn.Sdk
         // by the media API.
         private static String removeAdditionalFields(String json)
         {
+            String[] recordFields = { "id", "key", "digest", "name", "mimetype", "size"};
             var o = JsonHelper.FromJson<JObject>(json);
 
-            
-            o.Remove("createdAt");
-            o.Remove("id");
-    
+            foreach (var p in o.Properties())
+            {
+                if (!Array.Exists(recordFields, p.Name.Equals))
+                {
+                    p.Remove();
+                }
+            }
+
             return JsonHelper.ToJson(o);
 
    }

--- a/Sdk/Sdk/FileRecord.cs
+++ b/Sdk/Sdk/FileRecord.cs
@@ -113,6 +113,8 @@ namespace Stratumn.Sdk
                     if (json != null)
                     {
                         //attempt to generate FileRecord from json.
+                        json = removeAdditionalFields(json);
+
                         Object ob = JsonHelper.FromJson<FileRecord>(json);
                         String json2 = JsonHelper.ToCanonicalJson(ob);
                         if (json2.Equals(json))
@@ -125,6 +127,21 @@ namespace Stratumn.Sdk
             return isFileRecord;
         }
 
+        // Since we do a canonicalized JSON string comparison to check if the object is a 
+        // FileRecord above, we need to remove the additional fields that can be added
+        // by the media API.
+        private static String removeAdditionalFields(String json)
+        {
+            var o = JsonHelper.FromJson<JObject>(json);
 
-    }
+            
+            o.Remove("createdAt");
+            o.Remove("id");
+    
+            return JsonHelper.ToJson(o);
+
+   }
+
+
+}
 }

--- a/Sdk/Sdk/Model/File/FileInfo.cs
+++ b/Sdk/Sdk/Model/File/FileInfo.cs
@@ -18,15 +18,14 @@ namespace Stratumn.Sdk.Model.File
         private string name;
         private string key;
 
-
-        public FileInfo(string name, long size, string mimetype, string key) //: base(name)
+        public FileInfo(string name, long size, string mimetype, string key)
         {
 
 
             if (string.ReferenceEquals(name, null))
             {
                 throw new System.ArgumentException("name cannot be null");
-            } 
+            }
             if (string.ReferenceEquals(mimetype, null))
             {
                 throw new System.ArgumentException("mimetype cannot be null");

--- a/Sdk/Sdk/Sdk.cs
+++ b/Sdk/Sdk/Sdk.cs
@@ -18,7 +18,7 @@
     using Stratumn.Sdk.Model.Misc;
     using Stratumn.Sdk.Model.File;
     using System.IO;
-    using System.Diagnostics;
+    using FileInfo = Model.File.FileInfo;
 
     /// <summary>
     /// Defines the <see cref="Sdk{TState}" />
@@ -455,8 +455,11 @@
             {
                 FileRecord fileRecord = fileRecordProp.Value.Value;
                 MemoryStream file = await client.DownloadFile(fileRecord);
-                fileWrapperList.Add(
-                    fileRecordProp.Value.Transform((T) => FileWrapper.FromFileBlob(file,fileRecord.GetFileInfo())));
+                FileInfo info = fileRecord.GetFileInfo();
+                // When downloading a file, set disableEncrpytion to true if no key is passed so that the
+                // FileWrapper doesn't generate a new key and try to decrypt the file data.
+                FileWrapper fileWrapper = new FileBlobWrapper(file, info, info.Key == null || info.Key == "");
+                fileWrapperList.Add(fileRecordProp.Value.Transform((T) => fileWrapper));
             }
             return fileWrapperList;
         }


### PR DESCRIPTION
when initiating FileBlobWrapper, we explicitly pass the file info. The same class is used everywhere, which is confusing because it also contains the user file encryption key.
When the user inits a FileBlobWrapper,, he should be able to pass a null key to delegate the creation of a random key to the SDK (same as in the FilePathWrapper). Right now, when he passes the null key, the decryption is disabled.

Note: I has to create an other (internal) constructor for FileBlobWrapper where I can explicitly say if encryption is disabled or not so that we can still download non unencrypted files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/sdk-csharp/11)
<!-- Reviewable:end -->
