### PR TITLE
make sure isFileWrapper returns early if it finds a filewrapper

### DIFF
--- a/Sdk/Sdk/Client.cs
+++ b/Sdk/Sdk/Client.cs
@@ -67,7 +67,7 @@ namespace Stratumn.Sdk
             agents.Add(String.Format("CSharp/{0}", System.Environment.Version));
             agents.Add(String.Format("stratumn-sdk-csharp/{0}", Assembly.GetAssembly(typeof(Client)).GetName().Version.ToString()));
 
-            
+
             this.userAgent = String.Join(" ", agents.ToArray());
         }
 
@@ -223,11 +223,11 @@ namespace Stratumn.Sdk
             {
                 opts = new FetchOptions();
             }
-           
+
             string path = this.endpoints.GetEndpoint(service) + '/' + route;
 
             Uri url = new Uri(path);
-           
+
             HttpContent httpContent = new StringContent(body, Encoding.UTF8, "application/json");
 
 
@@ -568,7 +568,7 @@ namespace Stratumn.Sdk
             HttpResponseMessage clientResponse = await this.GetAsync<String>(Service.MEDIA, "files/" + fileRecord.Digest + "/info", null, null);
 
             string jsonResponse = await clientResponse.Content.ReadAsStringAsync();
-            var tokenJson = JsonConvert.DeserializeObject<Newtonsoft.Json.Linq.JObject> (jsonResponse);
+            var tokenJson = JsonConvert.DeserializeObject<Newtonsoft.Json.Linq.JObject>(jsonResponse);
 
             string downloadURL = tokenJson.GetValue("download_url").ToString();
 
@@ -583,7 +583,7 @@ namespace Stratumn.Sdk
 
             // Get the response.  
             HttpWebResponse response = (HttpWebResponse)httpConn.GetResponse();
-            
+
 
             HttpStatusCode status = response.StatusCode;
             if (status != HttpStatusCode.OK)
@@ -604,8 +604,8 @@ namespace Stratumn.Sdk
                 {
                     baos.Write(buffer, 0, bytesRead);
                 }
-            
-            
+
+
             }
 
 
@@ -635,8 +635,9 @@ namespace Stratumn.Sdk
             try
             {
                 response = await GraphqlExecute(gqlUrl, query, variables, opts);
-                
-            } catch (GraphQLHttpException e)
+
+            }
+            catch (GraphQLHttpException e)
             {
                 int retry = opts.Retry;
                 // handle errors explicitly 

--- a/Sdk/Sdk/FileWrapper.cs
+++ b/Sdk/Sdk/FileWrapper.cs
@@ -104,70 +104,47 @@ namespace Stratumn.Sdk
 
         public static Boolean isFileWrapper(Object obj)
         {
-            bool isFileWrapper = false;
+            // If the object is already of type FileWrapper return true
+            if (obj.ToString() == "Stratumn.Sdk.FilePathWrapper") return true;
+            if (obj.ToString() == "Stratumn.Sdk.FileBlobWrapper") return true;
+            if (obj.ToString() == "Stratumn.Sdk.BrowserFileWrapper") return true;
+            if (obj == null) return false;
+            // For strings, assume it's a JSON string
+            if (obj is String)
+            {
+                string json = (string) obj;
+                Object fileWrapper = null;
+                // attempt to generate FileWrapper from json.
+                try
+                {
+                    if (json.ToUpper().Contains("PATH"))
+                    {
+                        fileWrapper = JsonHelper.FromJson<FilePathWrapper>(json);
+                    }
+                    else if (json.ToUpper().Contains("FILEINFO"))
+                    {
+                        fileWrapper = JsonHelper.FromJson<FileBlobWrapper>(json);
+                    }
+                    else if (json.ToUpper().Contains("FILE"))
+                    {
+                        fileWrapper = JsonHelper.FromJson<BrowserFileWrapper>(json);
+                    }
+                }
+                catch (Exception)
+                { // obj can not be converted
+                }
+                return fileWrapper != null;
+            }
+            // Otherwise, try to coerce from json
             try
             {
-                string json = null;
-
-                if (typeof(FileWrapper).IsInstanceOfType(obj))
-                {
-                    isFileWrapper = true;
-                }
-                else if (obj != null)
-                {
-                    if (obj is JObject)
-                    {
-                        json = JsonHelper.ToCanonicalJson(obj);
-                    }
-                    else if (obj is String) //assume json
-                    {
-                        try {
-                            json = Canonicalizer.Canonicalize((String)obj);
-                        } catch (Exception) {}
-                    }
-                    else
-                    {
-                        json = JsonHelper.ToCanonicalJson(obj);
-                    }
-
-                    if (json != null)
-                    {
-                        Object ob = null;
-                        // attempt to generate FileWrapper from json.
-                        try
-                        {
-                            if (json.ToUpper().Contains("PATH"))
-                            {
-                                ob = JsonHelper.FromJson<FilePathWrapper>(json);
-                            }
-                            else if (json.ToUpper().Contains("FILEINFO"))
-                            {
-                                ob = JsonHelper.FromJson<FileBlobWrapper>(json);
-                            }
-                            else if (json.ToUpper().Contains("FILE"))
-                            {
-                                ob = JsonHelper.FromJson<BrowserFileWrapper>(json);
-                            }
-                        }
-                        catch (Exception)
-                        { // obj can not be converted
-                        }
-                        if (ob != null)
-                        {
-                            String json2 = JsonHelper.ToCanonicalJson(ob);
-                            if (json2.Equals(json))
-                            {
-                                isFileWrapper = true;
-                            }
-                        }
-                    }
-                }
+                FileWrapper fileWrapper = FromObject(obj);
+                return fileWrapper.Info() != null;
             }
-            catch (Exception ex)
+            catch (Exception)
             {
-                Console.WriteLine(ex.Message);
+                return false;
             }
-            return isFileWrapper;
         }
 
         public static FileWrapper FromObject(Object obj)

--- a/Sdk/Sdk/Sdk.cs
+++ b/Sdk/Sdk/Sdk.cs
@@ -78,7 +78,7 @@ namespace Stratumn.Sdk
             Dictionary<string, object> variables = new Dictionary<string, object>() { { "workflowId", workflowId } };
 
 
-            
+
             GraphQLResponse<dynamic> jsonResponse = await this.client.GraphqlAsync(query, variables, null, null);
 
             var jsonData = jsonResponse.Data;
@@ -155,7 +155,7 @@ namespace Stratumn.Sdk
                 else
                     throw new Exception("Cannot get signing private key");
             }
-            
+
             this.config = new SdkConfig(workflowId, configId, userId, accountId, groupId, ownerId, signingPrivateKey);
 
             // return the new config
@@ -190,7 +190,7 @@ namespace Stratumn.Sdk
             Dictionary<string, object> linkObj = JsonHelper.ObjectToMap(link.GetLink());
 
 
-            Dictionary <string, object> dataObj = JsonHelper.ObjectToMap(((TraceLink<TLinkData>)link).FormData());
+            Dictionary<string, object> dataObj = JsonHelper.ObjectToMap(((TraceLink<TLinkData>)link).FormData());
 
             Dictionary<string, object> variables = new Dictionary<string, object>
             {
@@ -205,7 +205,8 @@ namespace Stratumn.Sdk
                 var trace = jsonResponse.Data.createLink.trace;
 
                 return this.MakeTraceState<TLinkData>(trace);
-            } catch (TraceSdkException e)
+            }
+            catch (TraceSdkException e)
             {
                 if (firstTry && e.Message == ERROR_CONFIG_DEPRECATED)
                 {
@@ -217,7 +218,7 @@ namespace Stratumn.Sdk
 
                 throw e;
             }
-            
+
         }
 
         /// <summary>
@@ -359,14 +360,14 @@ namespace Stratumn.Sdk
 
 
                     TotalCount = totalCount,
-                    Info = nodes.Count>=1? info.ToObject<Info>():null
+                    Info = nodes.Count >= 1 ? info.ToObject<Info>() : null
                 };
                 return tracesList;
             }
 
             // comAdde detail for error
             String stageDetail = stageType.ToString() + actionKey ?? "";
-            
+
             // throw if no stages were found if
             if (stages.size() == 0)
             {
@@ -402,12 +403,12 @@ namespace Stratumn.Sdk
                 //get the fileWrapper property by index of file in the list uploaded.
                 Property<FileWrapper> fileWrapperProp = fileWrapperMap[fileList[i].GetId()];
                 //build FileRecord property
-                Property<FileRecord> fileRecordProp = fileWrapperProp.Transform((f)=> new FileRecord(mediaRecord, f.Info()));
+                Property<FileRecord> fileRecordProp = fileWrapperProp.Transform((f) => new FileRecord(mediaRecord, f.Info()));
                 fileRecordList.Add(fileRecordProp);
             }
 
 
-            Helpers.AssignObjects(fileRecordList); 
+            Helpers.AssignObjects(fileRecordList);
         }
 
         public async Task UploadFilesInObject(object data)
@@ -442,8 +443,8 @@ namespace Stratumn.Sdk
         public async Task<TData> DownloadFilesInObject<TData>(TData data)
         {
             Dictionary<string, Property<FileRecord>> fileRecordMap = Helpers.ExtractFileRecords(data);
-            List <Property<FileWrapper>> fileWrapperList =await this.DownloadFiles(fileRecordMap);
-            Helpers.AssignObjects(fileWrapperList); 
+            List<Property<FileWrapper>> fileWrapperList = await this.DownloadFiles(fileRecordMap);
+            Helpers.AssignObjects(fileWrapperList);
             return data;
         }
 
@@ -465,7 +466,7 @@ namespace Stratumn.Sdk
             }
             return fileWrapperList;
         }
-        
+
 
         /// <summary>
         /// The MakeTraceState
@@ -514,7 +515,7 @@ namespace Stratumn.Sdk
             string groupId = sdkConfig.GroupId;
 
             // upload files and transform data
-           await this.UploadFilesInLinkData(data);
+            await this.UploadFilesInLinkData(data);
 
             TraceLinkBuilderConfig<TLinkData> cfg = new TraceLinkBuilderConfig<TLinkData>()
             {
@@ -600,7 +601,7 @@ namespace Stratumn.Sdk
             SdkConfig sdkConfig = await this.GetConfigAsync();
 
             string workflowId = sdkConfig.WorkflowId;
-            string configId = sdkConfig.ConfigId; 
+            string configId = sdkConfig.ConfigId;
             string userId = sdkConfig.UserId;
 
             TraceLinkBuilderConfig<TLinkData> cfg = new TraceLinkBuilderConfig<TLinkData>()


### PR DESCRIPTION
This fixes an issue where ExtractFileWrappers can skip over large files.

```c#
state = await GetSdk().GetTraceStateAsync<object>(new GetTraceStateInput(traceId));
Object dataWithRecords = state.HeadLink.FormData();

object dataWithFiles = await GetSdk().DownloadFilesInObject(dataWithRecords); // <-- this already gets fileWrappers
IDictionary<String, Property<FileWrapper>> fileWrappers = Helpers.ExtractFileWrappers(dataWithFiles); // <-- this will skip large files for some reason 🤷 
foreach (Property<FileWrapper> fileWrapperProp in fileWrappers.Values)
{
   WriteFileToDisk(fileWrapperProp.Value);
}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/sdk-csharp/14)
<!-- Reviewable:end -->
