### PR TITLE
BTA-391: Remove link and group owner

### DIFF
--- a/SDKTest/SdkTest.cs
+++ b/SDKTest/SdkTest.cs
@@ -281,9 +281,8 @@ namespace SDKTest
         {
             await NewTraceTest();
             Assert.NotNull(someTraceState);
-            IDictionary<string, object> data = new Dictionary<string, object>() { { "why", "because im testing the pushTrace 2" } };
 
-            PushTransferInput<object> push = new PushTransferInput<object>(someTraceState.TraceId, OTHER_GROUP, data, null);
+            PushTransferInput<object> push = new PushTransferInput<object>(someTraceState.TraceId, OTHER_GROUP, new object(), null);
             someTraceState = await GetSdk().PushTraceAsync<object>(push);
 
             Assert.NotNull(push.TraceId);
@@ -349,8 +348,8 @@ namespace SDKTest
                 ["operation"] = "my new operation 1"
             };
 
-            data.Add("Certificate1", FileWrapper.FromFilePath(GetTestFilePath()));
-            data.Add("Certificates", new Identifiable[] { FileWrapper.FromFilePath(GetTestFilePath()) });
+            data.Add("certificate1", FileWrapper.FromFilePath(GetTestFilePath()));
+            data.Add("certificates", new Identifiable[] { FileWrapper.FromFilePath(GetTestFilePath()) });
 
             NewTraceInput<Object> newTraceInput = new NewTraceInput<Object>(ACTION_KEY, data);
 
@@ -377,7 +376,7 @@ namespace SDKTest
             await sdk.UploadFilesInLinkData(data);
 
             Assert.True(FileRecord.IsFileRecord(data["Certificate1"]));
-            Assert.True(FileRecord.IsFileRecord(((object[]) data["Certificates"])[0]));
+            Assert.True(FileRecord.IsFileRecord(((object[])data["Certificates"])[0]));
 
             Debug.WriteLine(JsonHelper.ToJson(data));
         }

--- a/SDKTest/SdkTestWithPojo.cs
+++ b/SDKTest/SdkTestWithPojo.cs
@@ -29,7 +29,7 @@ namespace SDKTest
         private const string TRACE_URL = "https://trace-api.staging.stratumn.com";
         private const string ACCOUNT_URL = "https://account-api.staging.stratumn.com";
         private const string MEDIA_URL = "https://media-api.staging.stratumn.com";
-        
+
         // used to pass the trace from one test method to another
         private TraceState<StateExample, DataClass> someTraceState;
 
@@ -210,16 +210,9 @@ namespace SDKTest
 
             await NewTraceTestWithPojo();
             Assert.NotNull(someTraceState);
-            Dictionary<string, object> data = new Dictionary<string, object>() { { "why", "because im testing the pushTrace 2" } };
 
-            DataClass d = new DataClass()
-            {
-                f11 = 1,
-                f22 = data
-            };
-
-            PushTransferInput<DataClass> push = new PushTransferInput<DataClass>(someTraceState.TraceId, OTHER_GROUP, d, null);
-            someTraceState = await sdk.PushTraceAsync<DataClass>(push);
+            PushTransferInput<Object> push = new PushTransferInput<Object>(someTraceState.TraceId, OTHER_GROUP, new Object(), null);
+            await sdk.PushTraceAsync<Object>(push);
 
             Assert.NotNull(push.TraceId);
         }
@@ -228,16 +221,9 @@ namespace SDKTest
         public async Task AcceptTransferTestWithPojo()
         {
             await PushTraceTestWithPojo();
-            Dictionary<string, object> data = new Dictionary<string, object>() { { "why", "because im testing the pushTrace 2" } };
 
-            DataClass d = new DataClass()
-            {
-                f11 = 1,
-                f22 = data
-            };
-
-            TransferResponseInput<DataClass> trInput = new TransferResponseInput<DataClass>(someTraceState.TraceId, d, null);
-            TraceState<StateExample, DataClass> stateAccept = await GetOtherGroupSdk<StateExample>().AcceptTransferAsync<DataClass>(trInput);
+            TransferResponseInput<Object> trInput = new TransferResponseInput<Object>(someTraceState.TraceId, new Object(), null);
+            TraceState<StateExample, Object> stateAccept = await GetOtherGroupSdk<StateExample>().AcceptTransferAsync<Object>(trInput);
 
             Assert.NotNull(stateAccept.TraceId);
         }
@@ -271,18 +257,11 @@ namespace SDKTest
         [Fact]
         public async Task CancelTransferTestWithPojo()
         {
-            Dictionary<string, object> data = new Dictionary<string, object>() { { "why", "because im testing the pushTrace 2" } };
-
-            DataClass d = new DataClass()
-            {
-                f11 = 1,
-                f22 = data
-            };
 
             await PushTraceTestWithPojo();
 
-            TransferResponseInput<DataClass> responseInput = new TransferResponseInput<DataClass>(someTraceState.TraceId, d, null);
-            TraceState<StateExample, DataClass> statecancel = await GetSdk<StateExample>().CancelTransferAsync< DataClass>(responseInput);
+            TransferResponseInput<Object> responseInput = new TransferResponseInput<Object>(someTraceState.TraceId, new Object(), null);
+            TraceState<StateExample, Object> statecancel = await GetSdk<StateExample>().CancelTransferAsync<Object>(responseInput);
 
             Assert.NotNull(statecancel.TraceId);
         }
@@ -300,7 +279,7 @@ namespace SDKTest
         }
 
         public class Step
-        { 
+        {
             public Identifiable[] stp_form_section;
         }
 

--- a/Sdk/SDK.csproj
+++ b/Sdk/SDK.csproj
@@ -1,11 +1,11 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>Stratumn.SDK</PackageId>
     <Title>Stratumn SDK</Title>
     <Description>Stratumn services SDK</Description>
-    <Version>0.1.3.0</Version>
+    <Version>0.2.0.0</Version>
     <Authors>Stratumn</Authors>
     <Company>Stratumn</Company>
     <PackageIconUrl>https://avatars2.githubusercontent.com/u/15095987</PackageIconUrl>

--- a/Sdk/Sdk/Model/Sdk/SdkConfig.cs
+++ b/Sdk/Sdk/Model/Sdk/SdkConfig.cs
@@ -26,10 +26,6 @@ namespace Stratumn.Sdk.Model.Sdk
         private string groupId;
 
         /// <summary>
-        /// The owner id
-        /// </summary>
-        private string ownerId;
-        /// <summary>
         /// The private key used for signing links
         /// </summary>
         private Ed25519PrivateKeyParameters signingPrivateKey;
@@ -38,14 +34,13 @@ namespace Stratumn.Sdk.Model.Sdk
         {
         }
 
-        public SdkConfig(string workflowId, string configId, string userId, string accountId, string groupId, string ownerId, Ed25519PrivateKeyParameters signingPrivateKey)
+        public SdkConfig(string workflowId, string configId, string userId, string accountId, string groupId, Ed25519PrivateKeyParameters signingPrivateKey)
         {
             this.workflowId = workflowId;
             this.configId = configId;
             this.userId = userId;
             this.accountId = accountId;
             this.groupId = groupId;
-            this.ownerId = ownerId;
             this.signingPrivateKey = signingPrivateKey;
         }
 
@@ -106,18 +101,6 @@ namespace Stratumn.Sdk.Model.Sdk
             set
             {
                 this.groupId = value;
-            }
-        }
-
-        public virtual string OwnerId
-        {
-            get
-            {
-                return ownerId;
-            }
-            set
-            {
-                this.ownerId = value;
             }
         }
 

--- a/Sdk/Sdk/Model/Trace/ITraceLink.cs
+++ b/Sdk/Sdk/Model/Trace/ITraceLink.cs
@@ -15,7 +15,6 @@ namespace Stratumn.Sdk.Model.Trace
         TraceLinkType Type();
         Account CreatedBy();
         DateTime CreatedAt();
-        Account Owner();
         string Group();
         string Form();
         string LastForm();

--- a/Sdk/Sdk/Model/Trace/TraceLinkMetaData.cs
+++ b/Sdk/Sdk/Model/Trace/TraceLinkMetaData.cs
@@ -8,8 +8,6 @@ namespace Stratumn.Sdk.Model.Trace
     /// </summary>
     public class TraceLinkMetaData
     {
-        [JsonProperty(PropertyName = "ownerId")]
-        public string OwnerId { get; set; }
 
         [JsonProperty(PropertyName = "configId")]
         public string ConfigId { get; set; }
@@ -39,12 +37,8 @@ namespace Stratumn.Sdk.Model.Trace
         {
         }
 
-        internal TraceLinkMetaData(string ownerId, string configId, string groupId, string formId, string lastFormId, DateTime createdAt, string createdById, string[] inputs)
+        internal TraceLinkMetaData(string configId, string groupId, string formId, string lastFormId, DateTime createdAt, string createdById, string[] inputs)
         {
-            if (string.ReferenceEquals(ownerId, null))
-            {
-                throw new System.ArgumentException("ownerId cannot be null");
-            }
             if (string.ReferenceEquals(configId, null))
             {
                 throw new System.ArgumentException("configId cannot be null");
@@ -74,7 +68,6 @@ namespace Stratumn.Sdk.Model.Trace
                 throw new System.ArgumentException("inputs cannot be null");
             }
 
-            this.OwnerId = ownerId;
             this.ConfigId = configId;
             this.GroupId = groupId;
             this.FormId = formId;

--- a/Sdk/Sdk/Sdk.cs
+++ b/Sdk/Sdk/Sdk.cs
@@ -1,4 +1,4 @@
-using GraphQL;
+﻿using GraphQL;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -77,8 +77,6 @@ namespace Stratumn.Sdk
 
             Dictionary<string, object> variables = new Dictionary<string, object>() { { "workflowId", workflowId } };
 
-
-
             GraphQLResponse<dynamic> jsonResponse = await this.client.GraphqlAsync(query, variables, null, null);
 
             var jsonData = jsonResponse.Data;
@@ -110,9 +108,13 @@ namespace Stratumn.Sdk
             // get all the groups that are owned by one of my accounts
             foreach (var _group in groups.nodes)
             {
-                if (myAccounts.Contains((String)_group.accountId))
+                foreach (var member in _group.members.nodes)
                 {
-                    myGroups.Add((Object)_group);
+
+                    if (myAccounts.Contains((String)member.accountId))
+                    {
+                        myGroups.Add((Object)_group);
+                    }
                 }
             }
 
@@ -132,7 +134,6 @@ namespace Stratumn.Sdk
             var group = myGroups.ToArray<Object>()[0];
             var groupObject = JsonConvert.DeserializeObject<GroupResponse>(group.ToString());
             String groupId = groupObject.GroupId;
-            String ownerId = groupObject.AccountId;
 
             Ed25519PrivateKeyParameters signingPrivateKey;
 
@@ -156,7 +157,7 @@ namespace Stratumn.Sdk
                     throw new Exception("Cannot get signing private key");
             }
 
-            this.config = new SdkConfig(workflowId, configId, userId, accountId, groupId, ownerId, signingPrivateKey);
+            this.config = new SdkConfig(workflowId, configId, userId, accountId, groupId, signingPrivateKey);
 
             // return the new config
             return this.config;
@@ -511,7 +512,6 @@ namespace Stratumn.Sdk
             string workflowId = sdkConfig.WorkflowId;
             string configId = sdkConfig.ConfigId;
             string userId = sdkConfig.UserId;
-            string ownerId = sdkConfig.OwnerId;
             string groupId = sdkConfig.GroupId;
 
             // upload files and transform data
@@ -528,7 +528,7 @@ namespace Stratumn.Sdk
             TraceLinkBuilder<TLinkData> linkBuilder = new TraceLinkBuilder<TLinkData>(cfg);
 
             // this is an attestation
-            linkBuilder.ForAttestation(actionKey, data).WithOwner(ownerId).WithGroup(groupId).WithCreatedBy(userId);
+            linkBuilder.ForAttestation(actionKey, data).WithGroup(groupId).WithCreatedBy(userId);
             // call createLink helper
             return await this.CreateLinkAsync(linkBuilder);
         }
@@ -555,7 +555,6 @@ namespace Stratumn.Sdk
             string workflowId = sdkConfig.WorkflowId;
             string configId = sdkConfig.ConfigId;
             string userId = sdkConfig.UserId;
-            string ownerId = sdkConfig.OwnerId;
             string groupId = sdkConfig.GroupId;
             // upload files and transform data
             await this.UploadFilesInLinkData(data);
@@ -575,7 +574,6 @@ namespace Stratumn.Sdk
 
             // this is an attestation
             linkBuilder.ForAttestation(actionKey, data)
-                    .WithOwner(ownerId)
                     .WithGroup(groupId)
                     .WithCreatedBy(userId);
             // call createLink helper
@@ -788,7 +786,6 @@ namespace Stratumn.Sdk
             String workflowId = sdkConfig.WorkflowId;
             string configId = sdkConfig.ConfigId;
             String userId = sdkConfig.UserId;
-            String ownerId = sdkConfig.OwnerId;
             String groupId = sdkConfig.GroupId;
 
             TraceLinkBuilderConfig<TLinkData> cfg = new TraceLinkBuilderConfig<TLinkData>()
@@ -806,8 +803,6 @@ namespace Stratumn.Sdk
 
             // this is an attestation
             linkBuilder.ForAcceptTransfer(data)
-               // add owner info
-               .WithOwner(ownerId)
                // add group info
                .WithGroup(groupId)
                // add creator info
@@ -836,7 +831,6 @@ namespace Stratumn.Sdk
             String workflowId = sdkConfig.WorkflowId;
             string configId = sdkConfig.ConfigId;
             String userId = sdkConfig.UserId;
-            String ownerId = sdkConfig.OwnerId;
             String groupId = sdkConfig.GroupId;
 
             TraceLinkBuilderConfig<TLinkData> cfg = new TraceLinkBuilderConfig<TLinkData>()
@@ -854,8 +848,6 @@ namespace Stratumn.Sdk
 
             // this is a push transfer
             linkBuilder.ForRejectTransfer(data)
-               // add owner info
-               .WithOwner(ownerId)
                // add group info
                .WithGroup(groupId)
                // add creator info

--- a/Sdk/Sdk/TraceLink.cs
+++ b/Sdk/Sdk/TraceLink.cs
@@ -45,7 +45,7 @@ namespace Stratumn.Sdk
         /// <returns></returns>
         new public TraceLinkMetaData Metadata()
         {
-            TraceLinkMetaData traceLinkMd = JsonHelper.ObjectToObject< TraceLinkMetaData>(base.Metadata());
+            TraceLinkMetaData traceLinkMd = JsonHelper.ObjectToObject<TraceLinkMetaData>(base.Metadata());
             return traceLinkMd;
         }
 
@@ -57,11 +57,6 @@ namespace Stratumn.Sdk
         public DateTime CreatedAt()
         {
             return this.Metadata().CreatedAt;
-        }
-
-        public Account Owner()
-        {
-            return new Account(this.Metadata().OwnerId);
         }
 
         /// <summary>

--- a/Sdk/Sdk/TraceLinkBuilder.cs
+++ b/Sdk/Sdk/TraceLinkBuilder.cs
@@ -100,7 +100,7 @@ namespace Stratumn.Sdk
                         )
                     )
                 );
-               
+
                 IDictionary<string, object> data = new Dictionary<string, object>();
                 data["algo"] = algo;
                 data["hash"] = hash;
@@ -112,13 +112,13 @@ namespace Stratumn.Sdk
 
         /// <summary>
         /// Helper method used to configure a link for an attestation. User must still
-        /// set owner, group and createdBy separately.
+        /// set group and createdBy separately.
         /// </summary>
         /// <param name="actionKey"> the form id used for the attestation </param>
         /// <param name="data">   the data of the attestation </param>
         /// <returns>The <see cref="TraceLinkBuilder{TLinkData}"/></returns>
         public TraceLinkBuilder<TLinkData> ForAttestation(string actionKey, TLinkData data)
-        {          
+        {
             string typeStr = TraceLinkType.OWNED.ToString();
             this.WithHashedData(data)
                     .WithAction(actionKey)
@@ -129,7 +129,7 @@ namespace Stratumn.Sdk
 
         /// <summary>
         /// Helper method used for transfer of ownership requests (push). Note
-        /// that owner and group are calculated from parent link. Parent link must have
+        /// that group is calculated from parent link. Parent link must have
         /// been provided!
         /// </summary>
         /// <param name="to">     the group to which the transfer is made for </param>
@@ -140,11 +140,10 @@ namespace Stratumn.Sdk
         public TraceLinkBuilder<TLinkData> ForTransferRequest(string to, TraceActionType action, TraceLinkType type, TLinkData data)
         {
             TraceLink<TLinkData> parent = this.ParentLink;
-            this.WithOwner(parent.Owner().GetAccount())
-                    .WithGroup(parent.Group())
-                        .WithHashedData(data)
-                            .WithAction(action.ToString())
-                                 .WithProcessState(type.ToString());
+            this.WithGroup(parent.Group())
+                  .WithHashedData(data)
+                  .WithAction(action.ToString())
+                  .WithProcessState(type.ToString());
 
             this.metadata.Inputs = new string[] { to };
             this.metadata.LastFormId = parent.Form() != null ? parent.Form() : parent.LastForm();
@@ -163,8 +162,8 @@ namespace Stratumn.Sdk
         }
 
         /// <summary>
-        /// Helper method used to cancel a transfer request. Note that owner and group
-        /// are calculated from parent link. Parent link must have been provided!
+        /// Helper method used to cancel a transfer request. Note that group
+        /// is calculated from parent link. Parent link must have been provided!
         /// </summary>
         /// <param name="data"> the optional data </param>
         /// <returns>The <see cref="TraceLinkBuilder{TLinkData}"/></returns>
@@ -173,17 +172,16 @@ namespace Stratumn.Sdk
             TraceLink<TLinkData> parent = this.ParentLink;
             string action = TraceActionType.CANCEL_TRANSFER.ToString();
             string type = TraceLinkType.OWNED.ToString();
-            this.WithOwner(parent.Owner().GetAccount())
-                    .WithGroup(parent.Group())
-                        .WithHashedData(data)
-                            .WithAction(action)
-                                .WithProcessState(type);
+            this.WithGroup(parent.Group())
+                  .WithHashedData(data)
+                  .WithAction(action)
+                  .WithProcessState(type);
             return this;
         }
 
         /// <summary>
-        /// Helper method used to reject a transfer request. Note that owner and group
-        /// are calculated from parent link. Parent link must have been provided!
+        /// Helper method used to reject a transfer request. Note that group
+        /// is calculated from parent link. Parent link must have been provided!
         /// </summary>
         /// <param name="data"> the optional data </param>
         /// <returns>The <see cref="TraceLinkBuilder{TLinkData}"/></returns>
@@ -193,17 +191,16 @@ namespace Stratumn.Sdk
             string action = TraceActionType.REJECT_TRANSFER.ToString();
             string type = TraceLinkType.OWNED.ToString();
 
-            this.WithOwner(parent.Owner().GetAccount())
-                    .WithGroup(parent.Group())
-                        .WithHashedData(data)
-                            .WithAction(action)
-                                .WithProcessState(type);
+            this.WithGroup(parent.Group())
+                  .WithHashedData(data)
+                  .WithAction(action)
+                  .WithProcessState(type);
             return this;
         }
 
         /// <summary>
         /// Helper method used to accept a transfer request. Parent link must have been
-        /// provided! User must still set owner, group and createdBy separately.
+        /// provided! User must still set group and createdBy separately.
         /// </summary>
         /// <param name="data"> the optional data </param>
         /// <returns>The <see cref="TraceLinkBuilder{TLinkData}"/></returns>
@@ -219,17 +216,6 @@ namespace Stratumn.Sdk
                 this.WithHashedData(data).WithAction(action).WithProcessState(type);
 
             }
-            return this;
-        }
-
-        /// <summary>
-        /// To set the metadata ownerId.
-        /// </summary>
-        /// <param name="ownerId"> the owner id </param>
-        /// <returns>The <see cref="TraceLinkBuilder{TLinkData}"/></returns>
-        public virtual TraceLinkBuilder<TLinkData> WithOwner(string ownerId)
-        {
-            this.metadata.OwnerId = ownerId;
             return this;
         }
 

--- a/Sdk/Sdk/graphql.cs
+++ b/Sdk/Sdk/graphql.cs
@@ -2,7 +2,7 @@ namespace Stratumn.Sdk
 {
     public static class GraphQL
     {
-        public const string FRAGMENT_PAGINATIONINFO_ONLINKSCONNECTION = 
+        public const string FRAGMENT_PAGINATIONINFO_ONLINKSCONNECTION =
             @"fragment PaginationInfoOnLinksConnectionFragment on LinksConnection {
                 totalCount
                 info: pageInfo {
@@ -94,7 +94,11 @@ namespace Stratumn.Sdk
                     groups {
                         nodes {
                             groupId: rowId
-                            accountId: ownerId
+                            members {
+                                nodes {
+                                    accountId
+                                }
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
- remove mentions to link owner. At this point, owner_id should not be required by the API anymore
- remove usage of group.owner
- use group members instead to find the group which the SDK user is part of

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/sdk-csharp/16)
<!-- Reviewable:end -->
