### PR TITLE
Update Graphql's version to get error's details in exceptions

### DIFF
--- a/Sdk/Sdk.csproj
+++ b/Sdk/Sdk.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -12,9 +12,8 @@
     <RepositoryUrl>https://github.com/stratumn/sdk-csharp</RepositoryUrl>
     <PackageTags>stratumn;sdk</PackageTags>
   </PropertyGroup>
-
   <ItemGroup>
-    <PackageReference Include="GraphQL.Client" Version="3.0.1" />
+    <PackageReference Include="GraphQL.Client" Version="3.2.4" />
     <PackageReference Include="GraphQL.Client.Serializer.Newtonsoft" Version="3.0.1" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
@@ -22,5 +21,4 @@
     <PackageReference Include="Stratumn.CanonicalJson" Version="0.0.8" />
     <PackageReference Include="Stratumn.Chainscript" Version="0.0.11.0" />
   </ItemGroup>
-
 </Project>

--- a/Sdk/Sdk/Client.cs
+++ b/Sdk/Sdk/Client.cs
@@ -635,15 +635,14 @@ namespace Stratumn.Sdk
             try
             {
                 response = await GraphqlExecute(gqlUrl, query, variables, opts);
-
             }
-            catch (GraphQLHttpException e)
+            catch (GraphQLHttpRequestException e)
             {
                 int retry = opts.Retry;
                 // handle errors explicitly 
                 // extract the status from the error response 
                 // if 401 and retry > 0 then we can retry
-                if (e.HttpResponseMessage.StatusCode == HttpStatusCode.Unauthorized && retry > 0)
+                if (e.StatusCode == HttpStatusCode.Unauthorized && retry > 0)
                 {
                     // unauthenticated request might be because token expired
                     // clear token and retry
@@ -652,7 +651,7 @@ namespace Stratumn.Sdk
                     return await this.GraphqlAsync(query, variables, opts, tclass);
                 }
                 // otherwise rethrow
-                throw new TraceSdkException(e.HttpResponseMessage.ReasonPhrase);
+                throw new TraceSdkException(e.Content);
             }
 
 
@@ -689,7 +688,7 @@ namespace Stratumn.Sdk
                 };
             else
                 httpHandler = new HttpClientHandler();
-            
+
             return httpHandler;
         }
 
@@ -713,7 +712,7 @@ namespace Stratumn.Sdk
             {
                 return await graphClient.SendQueryAsync<dynamic>(request);
             }
-            catch (GraphQLHttpException e)
+            catch (GraphQLHttpRequestException e)
             {
                 if (opts == null)
                 {
@@ -723,7 +722,7 @@ namespace Stratumn.Sdk
                 // handle errors explicitly 
                 // extract the status from the error response 
                 // if 401 and retry > 0 then we can retry
-                if (e.HttpResponseMessage.StatusCode == HttpStatusCode.Unauthorized && retry > 0)
+                if (e.StatusCode == HttpStatusCode.Unauthorized && retry > 0)
                 {
                     // unauthenticated request might be because token expired
                     // clear token and retry
@@ -733,7 +732,7 @@ namespace Stratumn.Sdk
                 }
 
                 // otherwise rethrow
-                throw new TraceSdkException(e.HttpResponseMessage.ReasonPhrase);
+                throw new TraceSdkException(e.Content);
             }
         }
     }


### PR DESCRIPTION
This PR makes possible to get the errors from GraphQL in order to make it easier for SDK users to understand what's wrong.

Before : "Bad Request"
Now : "{\"errors\":[{\"message\":\"Form data is not valid: [ should have required property 'deadline']\",\"locations\":[{\"line\":2,\"column\":17}],\"path\":[\"createLink\"],\"status\":400}],\"data\":{\"createLink\":null}}"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/sdk-csharp/27)
<!-- Reviewable:end -->
